### PR TITLE
起動時にNullReferenceExceptionが発生する問題を修正

### DIFF
--- a/TextClipper/ViewModels/MainWindowViewModel.cs
+++ b/TextClipper/ViewModels/MainWindowViewModel.cs
@@ -208,13 +208,13 @@ namespace TextClipper.ViewModels
 
         public void Initialize()
         {
-            model = Model.Instance;
             RaisePropertyChanged("ClippedTexts");
             RaisePropertyChanged("Plugins");
         }
 
         public MainWindowViewModel()
         {
+            model = Model.Instance;
             this._description = new DropAcceptDescription();
             this._description.DragOver += this.OnDragOver;
             this._description.DragDrop += this.OnDragDrop;


### PR DESCRIPTION
MainWindowViewModel.cs の 74行目 および 69行目で起動時にNullReferenceExceptionが発生します。
これはクラス変数modelがMainWindowViewModelクラスのコンストラクタで初期化されていないためです。

modelの初期化をInitializeメソッドではなくコンストラクタで行い、問題を対処しました。
